### PR TITLE
kube api takes time to get up, as first time  kublet-wrapper download…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,7 +99,7 @@
   command: curl -i --silent http://localhost:8080
   register: result
   until: result.stdout.find("200 OK") != -1
-  retries: 30
+  retries: 100
   delay: 10
   changed_when: false
 


### PR DESCRIPTION
…s and run all images  which seems to take time. Hence increasing the number of retries.
