### PR TITLE
set terminated pod gc threshold

### DIFF
--- a/templates/kube-controller-manager.yaml
+++ b/templates/kube-controller-manager.yaml
@@ -14,6 +14,9 @@ spec:
     - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --root-ca-file=/etc/kubernetes/ssl/ca.pem
     - --leader-elect=true
+{% if terminated_pod_gc_threshold is defined %}
+    - --terminated-pod-gc-threshold={{terminated_pod_gc_threshold}}
+{% endif %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1


### PR DESCRIPTION
This will help set the threshold for how many terminated pods are in the system across all namespaces. 
https://kubernetes.io/docs/admin/kube-controller-manager/

```
--terminated-pod-gc-threshold int32                                 Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled. (default 12500)
```

According to the above documentation the default value is 12500, which could be too high for several cases. This setting will help configure this.
