### PR TITLE
Ensure kube scheduler policy config dir exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,12 @@
   sudo: yes
   template: src=kube-controller-manager.yaml dest={{kube_manifests_dir}}/kube-controller-manager.yaml
 
+- name: ensures kube scheduler policy config dir exists
+  sudo: yes
+  file: path={{kube_scheduler_policy_config_dir}} state=directory mode=0755
+  when:
+    - kube_scheduler_policy_config_dir != ""
+
 - name: create scheduler config policy file
   sudo: yes
   template: src={{kube_scheduler_policy_config_file_src}} dest={{kube_scheduler_policy_config_dir}}/{{kube_scheduler_policy_config_file_name}}


### PR DESCRIPTION
The kube scheduler policy config dir needs to exist on coreos host, which is eventually mounted on to kube-scheduler container. The kube-scheduler will read the policy config file present in this dir, while starting up.

This change ensures that, the policy config dir is present on coreos host.