### PR TITLE
Remove deprecated options: --api-servers, --authorization-rbac-super-…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+kube_config_dir: "/etc/kubernetes"
 kube_cert_dir: "/etc/kubernetes/ssl"
 kube_manifests_dir: "/etc/kubernetes/manifests"
 kubernetes_service_addresses: "172.21.0.0/16"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: restart kubelet
+  sudo: true
+  service: name=kubelet state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,11 @@
   sudo: yes
   copy: content="{{ kube_apiserver_key_pem }}" dest="{{ kube_cert_dir }}/apiserver-key.pem"
 
+- name: install kubeconfig
+  sudo: yes
+  template: src=apiserver-kubeconfig.yaml dest={{kube_config_dir}}/apiserver-kubeconfig.yaml
+  notify: restart kubelet
+
 - name: create manifests directory
   sudo: yes
   file:

--- a/templates/apiserver-kubeconfig.yaml
+++ b/templates/apiserver-kubeconfig.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.pem
+    server: http://127.0.0.1:8080
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: kubelet-context
+current-context: kubelet-context

--- a/templates/kube-apiserver.yaml
+++ b/templates/kube-apiserver.yaml
@@ -27,7 +27,6 @@ spec:
         - --token-auth-file=/etc/auth/tokens.csv
         - --authorization-mode={{kube_authorization_mode}}
         - --authorization-policy-file=/etc/auth/policies.jsonl
-        - --authorization-rbac-super-user=kube-admin
         - --storage-backend={{kube_storage_backend}}
 {% if kube_enable_audit_logs %}
         - --audit-log-path={{kube_audit_log_path}}


### PR DESCRIPTION
…user

- Use kubeconfig instead of deprecated option '--api-servers'
- 'system:masters' group has privileged access
  https://github.com/kubernetes/kubernetes/pull/38121