### PR TITLE
Pass --apiserver-count to kube-apiserver

### DIFF
--- a/templates/kube-apiserver.yaml
+++ b/templates/kube-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
         - apiserver
         - --bind-address=0.0.0.0
         - --etcd-servers={{_etcd.peers()}}
+        - --apiserver-count={{groups['kubernetes-masters']|length}}
         - --allow-privileged=true
         - --service-cluster-ip-range={{kubernetes_service_addresses}}
         - --secure-port={{kube_apiserver_secure_port}}


### PR DESCRIPTION
- https://stackoverflow.com/a/36339537
  "kube-apiserver needs to know how many apiservers are in the cluster.
  You must provide the --apiserver-count=X flag to every member of the
  cluster, where X is the number of apiservers in the cluster."
- Fixes log spew in apiserver logs:
  "Resetting endpoints for master service "kubernetes" to &{{ } ..."