### PR TITLE
Add labels to kube-scheduler, kube-controller-manager pods

### DIFF
--- a/templates/kube-controller-manager.yaml
+++ b/templates/kube-controller-manager.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: kube-controller-manager
   namespace: kube-system
+  labels:
+    k8s-app: kube-controller-manager
 spec:
   containers:
   - name: kube-controller-manager

--- a/templates/kube-scheduler.yaml
+++ b/templates/kube-scheduler.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: kube-scheduler
   namespace: kube-system
+  labels:
+    k8s-app: kube-scheduler
 spec:
   hostNetwork: true
   containers:


### PR DESCRIPTION
Add labels to kube-scheduler, kube-controller-manager pods, so that their corresponding services select the pods and servicemonitor(prometheus) can subsequently monitor the services.