### PR TITLE
Add the ability to Enable admission controller

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,5 @@ kube_scheduler_verbosity: "3"
 enable_ext_scheduler: False
 
 kube_storage_backend: "etcd3"
+
+enable_external_admission_controller_webhook: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,10 +46,54 @@
 - name: register apiserver-key.pem
   set_fact:
     kube_apiserver_key_pem: "{{ apiserver_key_pem.content|b64decode }}"
-
 - name: place apiserver-key.pem
   sudo: yes
   copy: content="{{ kube_apiserver_key_pem }}" dest="{{ kube_cert_dir }}/apiserver-key.pem"
+
+- name: retrieve client-ca.pem
+  slurp:
+    src: "{{kubernetes_ca_depot}}/client-ca.pem"
+  register: client_ca_pem
+  run_once: true
+  delegate_to: "{{ groups['ca'][0] }}"
+
+- name: register client-ca.pem
+  set_fact:
+    kube_client_ca_pem: "{{ client_ca_pem.content|b64decode }}"
+
+- name: place client-ca.pem
+  sudo: yes
+  copy: content="{{ kube_client_ca_pem }}" dest="{{ kube_cert_dir }}/client-ca.pem"
+
+- name: retrieve client-key.pem
+  slurp:
+    src: "{{kubernetes_ca_depot}}/client-key.pem"
+  register: client_key_pem
+  run_once: true
+  delegate_to: "{{ groups['ca'][0] }}"
+
+- name: register client-key.pem
+  set_fact:
+    kube_client_key_pem: "{{ client_key_pem.content|b64decode }}"
+
+- name: place client-key.pem
+  sudo: yes
+  copy: content="{{ kube_client_key_pem }}" dest="{{ kube_cert_dir }}/client-key.pem"
+
+- name: retrieve client.pem
+  slurp:
+    src: "{{kubernetes_ca_depot}}/client.pem"
+  register: client_pem
+  run_once: true
+  delegate_to: "{{ groups['ca'][0] }}"
+
+- name: register client.pem
+  set_fact:
+    kube_client_pem: "{{ client_pem.content|b64decode }}"
+
+- name: place client.pem
+  sudo: yes
+  copy: content="{{ kube_client_pem }}" dest="{{ kube_cert_dir }}/client.pem"
 
 - name: install kubeconfig
   sudo: yes

--- a/templates/kube-apiserver.yaml
+++ b/templates/kube-apiserver.yaml
@@ -21,6 +21,12 @@ spec:
         - --secure-port={{kube_apiserver_secure_port}}
         - --advertise-address={{ansible_default_ipv4.address}}
         - --admission-control={{kube_admission_control}}
+{% if enable_external_admission_controller_webhook %}
+        - --runtime-config=admissionregistration.k8s.io/v1alpha1
+        - --proxy-client-cert-file={{kube_cert_dir}}/client.pem
+        - --proxy-client-key-file={{kube_cert_dir}}/client-key.pem
+        - --requestheader-client-ca-file={{kube_cert_dir}}/client-ca.pem
+{% endif %}
         - --tls-cert-file={{kube_cert_dir}}/apiserver.pem
         - --tls-private-key-file={{kube_cert_dir}}/apiserver-key.pem
         - --client-ca-file={{kube_cert_dir}}/ca.pem


### PR DESCRIPTION
Admission controller needs apiserver to connect to it
via https only. Both apiserver and admission controller need
to exchange certs. the communication is explained here.

https://github.com/caesarxuchao/example-webhook-admission-controller#explanation-on-the-cascertskeys
https://kubernetes.io/docs/admin/extensible-admission-controllers/

The latest doc on kubernetes might not be same as the implementation as
we may not be on the latest kubernetes version.