### PR TITLE
Enable Cloud Provider

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,7 @@ kube_storage_backend: "etcd3"
 enable_external_admission_controller_webhook: False
 
 kube_apiserver_runtime_config: "batch/v2alpha1=true{% if enable_external_admission_controller_webhook %},admissionregistration.k8s.io/v1beta1=true{% endif %}"
+
+kube_enable_cloud_provider: False
+kube_cloud_config_path: "/etc/kubernetes/cloud-config"
+kube_cloud_provider: "vsphere"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,6 +106,11 @@
     path={{ kube_manifests_dir }}
     state=directory
 
+- name: Copy cloud-config
+  sudo: yes
+  copy: src=cloud-config dest={{kube_cloud_config_path}} mode=0755
+  when: kube_enable_cloud_provider == True
+
 - name: create auth dir
   sudo: yes
   file: path={{kube_auth_dir}} state=directory

--- a/templates/kube-apiserver.yaml
+++ b/templates/kube-apiserver.yaml
@@ -40,6 +40,10 @@ spec:
         - --audit-log-maxsize={{kube_audit_log_maxsize}}
         - --audit-log-maxbackup={{kube_audit_log_maxbackup}}
 {% endif %}
+{% if kube_enable_cloud_provider %}
+        - --cloud-config={{kube_cloud_config_path}}
+        - --cloud-provider={{kube_cloud_provider}}
+{% endif %}
       resources:
         requests:
           cpu: {{kube_apiserver_requests_cpu}}
@@ -69,6 +73,11 @@ spec:
         - mountPath: /etc/auth
           name: auth-kubernetes
           readOnly: true
+{% if kube_enable_cloud_provider %}
+        - mountPath: {{kube_cloud_config_path}}
+          name: cloud-config
+          readOnly: true
+{% endif %}
   volumes:
     - hostPath:
         path: {{kube_cert_dir}}
@@ -79,3 +88,9 @@ spec:
     - hostPath:
         path: {{kube_auth_dir}}
       name: auth-kubernetes
+{% if kube_enable_cloud_provider %}
+    - hostPath:
+        path: {{kube_cloud_config_path}}
+        type: File
+      name: cloud-config
+{% endif %}

--- a/templates/kube-controller-manager.yaml
+++ b/templates/kube-controller-manager.yaml
@@ -19,6 +19,10 @@ spec:
 {% if terminated_pod_gc_threshold is defined %}
     - --terminated-pod-gc-threshold={{terminated_pod_gc_threshold}}
 {% endif %}
+{% if kube_enable_cloud_provider %}
+    - --cloud-config={{kube_cloud_config_path}}
+    - --cloud-provider={{kube_cloud_provider}}
+{% endif %}
     resources:
       requests:
         cpu: {{kube_controller_manager_requests_cpu}}
@@ -37,6 +41,11 @@ spec:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host
       readOnly: true
+{% if kube_enable_cloud_provider %}
+    - mountPath: {{kube_cloud_config_path}}
+      name: cloud-config
+      readOnly: true
+{% endif %}
   hostNetwork: true
   volumes:
   - hostPath:
@@ -45,3 +54,9 @@ spec:
   - hostPath:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
+{% if kube_enable_cloud_provider %}
+  - hostPath:
+      path: {{kube_cloud_config_path}}
+      type: File
+    name: cloud-config
+{% endif %}


### PR DESCRIPTION
This PR enables k8s cloud provider. The default is set to ```vSphere```. 
Instructions to enable vSphere Cloud Provider before launching this scripts:
1. Set  ```kube_enable_cloud_provider``` to True.
2. Create folder with name ```files```.
3. Create```vSphere.conf``` in folder that has name ```files```
