### PR TITLE
Enable PodPriority feature and set priorityClass for cluster components

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ kube_auth_dir: "/etc/kubernetes/auth"
 kube_users_map: {}
 kube_policies_list: []
 kube_authorization_mode: "ABAC,RBAC"
-kube_admission_control: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota"
+kube_admission_control: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority"
 kube_apiserver_secure_port: 6443
 
 kube_enable_audit_logs: True
@@ -19,13 +19,24 @@ kube_audit_log_maxsize: 50
 kube_audit_log_maxbackup: 0
 
 kube_apiserver_requests_cpu: "200m"
-kube_apiserver_requests_memory: "128Mi"
+kube_apiserver_requests_memory: "512Mi"
+kube_apiserver_limits_cpu: "200m" # requests and limits should be same to get Guaranteed QoS
+kube_apiserver_limits_memory: "512Mi"
 
 kube_scheduler_requests_cpu: "100m"
-kube_scheduler_requests_memory: "128Mi"
+kube_scheduler_requests_memory: "256Mi"
+kube_scheduler_limits_cpu: "100m" # requests and limits should be same to get Guaranteed QoS
+kube_scheduler_limits_memory: "256Mi"
 
-kube_controller_manager_requests_cpu: "200m"
-kube_controller_manager_requests_memory: "128Mi"
+kube_controller_manager_requests_cpu: "300m"
+kube_controller_manager_requests_memory: "768Mi"
+kube_controller_manager_limits_cpu: "300m" # requests and limits should be same to get Guaranteed QoS
+kube_controller_manager_limits_memory: "768Mi"
+
+kube_proxy_requests_cpu: "200m"
+kube_proxy_requests_memory: "128Mi"
+kube_proxy_limits_cpu: "200m" # requests and limits should be same to get Guaranteed QoS
+kube_proxy_limits_memory: "128Mi"
 
 kube_scheduler_policy_config_file_src: ""
 kube_scheduler_policy_config_dir: ""
@@ -38,7 +49,10 @@ kube_storage_backend: "etcd3"
 
 enable_external_admission_controller_webhook: False
 
-kube_apiserver_runtime_config: "batch/v2alpha1=true{% if enable_external_admission_controller_webhook %},admissionregistration.k8s.io/v1beta1=true{% endif %}"
+kube_apiserver_runtime_config:
+  "batch/v2alpha1=true\
+  ,scheduling.k8s.io/v1alpha1=true\
+  {% if enable_external_admission_controller_webhook %},admissionregistration.k8s.io/v1beta1=true{% endif %}"
 
 kube_enable_cloud_provider: False
 kube_cloud_config_path: "/etc/kubernetes/cloud-config"

--- a/templates/kube-apiserver.yaml
+++ b/templates/kube-apiserver.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: kube-system
 spec:
   hostNetwork: true
+  priorityClassName: system-node-critical
   containers:
     - name: kube-apiserver
       image: "{{hyperkube}}"
@@ -20,6 +21,7 @@ spec:
         - --service-cluster-ip-range={{kubernetes_service_addresses}}
         - --secure-port={{kube_apiserver_secure_port}}
         - --advertise-address={{ansible_default_ipv4.address}}
+        - --feature-gates=PodPriority=true
         - --admission-control={{kube_admission_control}}
         - --runtime-config={{ kube_apiserver_runtime_config }}
 {% if enable_external_admission_controller_webhook %}
@@ -48,6 +50,9 @@ spec:
         requests:
           cpu: {{kube_apiserver_requests_cpu}}
           memory: {{kube_apiserver_requests_memory}}
+        limits:
+          cpu: {{kube_apiserver_limits_cpu}}
+          memory: {{kube_apiserver_limits_memory}}
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/templates/kube-controller-manager.yaml
+++ b/templates/kube-controller-manager.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     k8s-app: kube-controller-manager
 spec:
+  priorityClassName: system-node-critical
   containers:
   - name: kube-controller-manager
     image: "{{hyperkube}}"
@@ -27,6 +28,9 @@ spec:
       requests:
         cpu: {{kube_controller_manager_requests_cpu}}
         memory: {{kube_controller_manager_requests_memory}}
+      limits:
+        cpu: {{kube_controller_manager_limits_cpu}}
+        memory: {{kube_controller_manager_limits_memory}}
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/templates/kube-proxy.yaml
+++ b/templates/kube-proxy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
 spec:
   hostNetwork: true
+  priorityClassName: system-node-critical
   containers:
   - name: kube-proxy
     image: "{{hyperkube}}"
@@ -13,6 +14,13 @@ spec:
     - proxy
     - --master=http://127.0.0.1:8080
     - --proxy-mode=iptables
+    resources:
+      requests:
+        cpu: {{kube_proxy_requests_cpu}}
+        memory: {{kube_proxy_requests_memory}}
+      limits:
+        cpu: {{kube_proxy_limits_cpu}}
+        memory: {{kube_proxy_limits_memory}}
     securityContext:
       privileged: true
     volumeMounts:

--- a/templates/kube-scheduler.yaml
+++ b/templates/kube-scheduler.yaml
@@ -7,6 +7,7 @@ metadata:
     k8s-app: kube-scheduler
 spec:
   hostNetwork: true
+  priorityClassName: system-node-critical
   containers:
   - name: kube-scheduler
     image: "{{hyperkube}}"
@@ -24,6 +25,9 @@ spec:
       requests:
         cpu: {{kube_scheduler_requests_cpu}}
         memory: {{kube_scheduler_requests_memory}}
+      limits:
+        cpu: {{kube_scheduler_limits_cpu}}
+        memory: {{kube_scheduler_limits_memory}}
     livenessProbe:
       httpGet:
         host: 127.0.0.1


### PR DESCRIPTION
Per https://v1-9.docs.kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
- Open PodPriority feature gate
- Enable scheduling.k8s.io/v1alpha1 API and Priority admission controller in API server
- Set priorityClassName system-node-critical (highest priority) for API Server, Controller Manager, Scheduler and Kube Proxy
- Set equal CPU and Memory requests and limits so that API Server, Controller Manager, Scheduler and Kube Proxy will get Guaranteed QoS. This is required per https://v1-9.docs.kubernetes.io/docs/tasks/administer-cluster/out-of-resource/ ("If necessary, kubelet evicts Pods one at a time to reclaim disk when DiskPressure is encountered. If the kubelet is responding to inode starvation, it reclaims inodes by evicting Pods with the lowest quality of service first. If the kubelet is responding to lack of available disk, it ranks Pods within a quality of service that consumes the largest amount of disk and kill those first.") As a side-effect, setting limits is a workaround for the Controller Manager memory leak https://github.com/kubernetes/kubernetes/issues/52657