### PR TITLE
Add ability to set log level for kube-proxy on master nodes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ kube_proxy_requests_cpu: "200m"
 kube_proxy_requests_memory: "128Mi"
 kube_proxy_limits_cpu: "200m" # requests and limits should be same to get Guaranteed QoS
 kube_proxy_limits_memory: "128Mi"
+kube_proxy_master_log_level: 0
 
 kube_scheduler_policy_config_file_src: ""
 kube_scheduler_policy_config_dir: ""

--- a/templates/kube-proxy.yaml
+++ b/templates/kube-proxy.yaml
@@ -12,6 +12,7 @@ spec:
     command:
     - /hyperkube
     - proxy
+    - -v={{kube_proxy_master_log_level}}
     - --master=http://127.0.0.1:8080
     - --proxy-mode=iptables
     resources:


### PR DESCRIPTION
-v is supported by kube-proxy (due to glog) for increasing verbosity of the logs.