### PR TITLE
Enable aggregation layer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,7 @@ enable_ext_scheduler: False
 kube_storage_backend: "etcd3"
 
 enable_external_admission_controller_webhook: False
+enable_aggregration_layer: False
 
 kube_apiserver_runtime_config:
   "batch/v2alpha1=true\

--- a/templates/kube-apiserver.yaml
+++ b/templates/kube-apiserver.yaml
@@ -24,10 +24,15 @@ spec:
         - --feature-gates=PodPriority=true
         - --admission-control={{kube_admission_control}}
         - --runtime-config={{ kube_apiserver_runtime_config }}
-{% if enable_external_admission_controller_webhook %}
+{% if enable_external_admission_controller_webhook  or enable_aggregration_layer %}
         - --proxy-client-cert-file={{kube_cert_dir}}/client.pem
         - --proxy-client-key-file={{kube_cert_dir}}/client-key.pem
         - --requestheader-client-ca-file={{kube_cert_dir}}/client-ca.pem
+{% endif %}
+{% if enable_aggregration_layer %}
+        - --requestheader-extra-headers-prefix=X-Remote-Extra-
+        - --requestheader-group-headers=X-Remote-Group
+        - --requestheader-username-headers=X-Remote-User
 {% endif %}
         - --tls-cert-file={{kube_cert_dir}}/apiserver.pem
         - --tls-private-key-file={{kube_cert_dir}}/apiserver-key.pem


### PR DESCRIPTION
Add kube-apiserver flags to enable aggregation layer. This is required
for extending apiserver with additional APIs like (metrics.k8s.io)