### PR TITLE
Add option to enable config file based auditing for api server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,10 +13,16 @@ kube_authorization_mode: "ABAC,RBAC"
 kube_admission_control: "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority"
 kube_apiserver_secure_port: 6443
 
+var_log_dir: "/var/log"
 kube_enable_audit_logs: True
-kube_audit_log_path: "/dev/stdout"
+kube_audit_config_dir: "/etc/kubernetes/kube-audit"
+kube_audit_policy_file: "{{kube_audit_config_dir}}/audit-policy.yaml"
+kube_audit_log_path: "{{var_log_dir}}/kube-audit/audit.log"
 kube_audit_log_maxsize: 50
-kube_audit_log_maxbackup: 0
+kube_audit_log_maxbackup: 1
+#By default don't audit anything
+kube_api_audit_rules_list:
+  - level: None
 
 kube_apiserver_requests_cpu: "200m"
 kube_apiserver_requests_memory: "512Mi"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,6 +100,15 @@
   template: src=apiserver-kubeconfig.yaml dest={{kube_config_dir}}/apiserver-kubeconfig.yaml
   notify: restart kubelet
 
+- name: create kube audit config dir
+  become: yes
+  file: path={{kube_audit_config_dir}} state=directory
+
+- name: copy kube audit policy file
+  become: yes
+  template: src=audit-policy.yaml dest={{kube_audit_policy_file}}
+  when: kube_enable_audit_logs
+
 - name: create manifests directory
   become: yes
   file:

--- a/templates/audit-policy.yaml
+++ b/templates/audit-policy.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+rules:
+  {{ kube_api_audit_rules_list | to_nice_yaml(indent=2) | indent(width=2, indentfirst=False) }}

--- a/templates/kube-apiserver.yaml
+++ b/templates/kube-apiserver.yaml
@@ -43,9 +43,11 @@ spec:
         - --authorization-policy-file=/etc/auth/policies.jsonl
         - --storage-backend={{kube_storage_backend}}
 {% if kube_enable_audit_logs %}
+        - --audit-policy-file={{kube_audit_policy_file}}
         - --audit-log-path={{kube_audit_log_path}}
         - --audit-log-maxsize={{kube_audit_log_maxsize}}
         - --audit-log-maxbackup={{kube_audit_log_maxbackup}}
+        - --audit-log-format=json
 {% endif %}
 {% if kube_enable_cloud_provider %}
         - --cloud-config={{kube_cloud_config_path}}
@@ -84,6 +86,14 @@ spec:
         - mountPath: /etc/auth
           name: auth-kubernetes
           readOnly: true
+{% if kube_enable_audit_logs %}
+        - mountPath: {{kube_audit_config_dir}}
+          name: kube-audit
+          readOnly: true
+        - mountPath: {{var_log_dir}}/kube-audit
+          subPath: kube-audit
+          name: var-log
+{% endif %}
 {% if kube_enable_cloud_provider %}
         - mountPath: {{kube_cloud_config_path}}
           name: cloud-config
@@ -99,6 +109,14 @@ spec:
     - hostPath:
         path: {{kube_auth_dir}}
       name: auth-kubernetes
+{% if kube_enable_audit_logs %}
+    - hostPath:
+        path: {{kube_audit_config_dir}}
+      name: kube-audit
+    - hostPath:
+        path: {{var_log_dir}}
+      name: var-log
+{% endif %}
 {% if kube_enable_cloud_provider %}
     - hostPath:
         path: {{kube_cloud_config_path}}


### PR DESCRIPTION
Tested on local cluster with sample audit files with different rules. Final rules borrowed from GCE.