### PR TITLE
Fix DECC-2231: remove livenessProbe in kube-proxy

### DIFF
--- a/templates/kube-proxy.yaml
+++ b/templates/kube-proxy.yaml
@@ -24,13 +24,6 @@ spec:
       limits:
         cpu: {{kube_proxy_limits_cpu}}
         memory: {{kube_proxy_limits_memory}}
-    livenessProbe:
-      httpGet:
-        host: 127.0.0.1
-        path: /healthz
-        port: 10255
-      initialDelaySeconds: 15
-      timeoutSeconds: 1
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
already have a default "--healthz-port" as 10256