### PR TITLE
Add labels, SYSTEM_NAMESPACES and SYSTEM_POD_LABELS, into extended-scheduler

### DIFF
--- a/templates/kube-scheduler.yaml
+++ b/templates/kube-scheduler.yaml
@@ -52,6 +52,10 @@ spec:
       value: {{ext_scheduler_label_keys}}
     - name: LOG_LEVEL
       value: {{ext_scheduler_log_level}}
+    - name: SYSTEM_NAMESPACES
+      value: {{ext_scheduler_system_namespaces}}
+    - name: SYSTEM_POD_LABELS
+      value: {{ext_scheduler_system_pod_labels}}
     livenessProbe:
       httpGet:
         host: 127.0.0.1


### PR DESCRIPTION
As I don't have write access, this pr is to "cherry-pick" [commit](https://github.com/vmware/ansible-coreos-kubernetes-master/commit/5d4bb6a9657d0ae2df02c89029f1631d95e75758) from branch `k8s-1.14.3` to `master`.