### PR TITLE
If kubernetes_enable_cni=True, start kube-controller-manager with --cluster-cidr and --allocate-node-cidrs options to support CNI Plugins (e.g. Antrea)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ kube_config_dir: "/etc/kubernetes"
 kube_cert_dir: "/etc/kubernetes/ssl"
 kube_manifests_dir: "/etc/kubernetes/manifests"
 kubernetes_service_addresses: "172.21.0.0/16"
+kubernetes_cluster_cidr: "172.34.0.0/16"
+kubernetes_enable_cni: False
 kubernetes_version: "1.14.3"
 hyperkube: "gcr.io/google_containers/hyperkube:v{{kubernetes_version}}"
 etcd_certs_root: "/etc/ssl/etcd"

--- a/templates/kube-controller-manager.yaml
+++ b/templates/kube-controller-manager.yaml
@@ -20,6 +20,10 @@ spec:
     - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --root-ca-file=/etc/kubernetes/ssl/ca.pem
     - --leader-elect=true
+{% if kubernetes_enable_cni %}
+    - --cluster-cidr={{kubernetes_cluster_cidr}}
+    - --allocate-node-cidrs=true
+{% endif %}
 {% if terminated_pod_gc_threshold is defined %}
     - --terminated-pod-gc-threshold={{terminated_pod_gc_threshold}}
 {% endif %}


### PR DESCRIPTION
If kubernetes_enable_cni=True, start kube-controller-manager with --cluster-cidr and --allocate-node-cidrs options to support CNI Plugins (e.g. Antrea)