### PR TITLE
If kubernetes_enable_cni=True, start kube-proxy with --cluster-cidr option to support CNI Plugins (e.g. Antrea)

### DIFF
--- a/templates/kube-proxy.yaml
+++ b/templates/kube-proxy.yaml
@@ -22,6 +22,9 @@ spec:
     - --metrics-bind-address=0.0.0.0
     - --metrics-port=10249
     - --proxy-mode=iptables
+{% if kubernetes_enable_cni %}
+    - --cluster-cidr={{kubernetes_cluster_cidr}}
+{% endif %}
     resources:
       requests:
         cpu: {{kube_proxy_requests_cpu}}


### PR DESCRIPTION
If kubernetes_enable_cni=True, start kube-proxy with --cluster-cidr option to support CNI Plugins (e.g. Antrea)