### PR TITLE
Increase Cluster NodePort Range from 30000-32767 to 20000-32767

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ kube_config_dir: "/etc/kubernetes"
 kube_cert_dir: "/etc/kubernetes/ssl"
 kube_manifests_dir: "/etc/kubernetes/manifests"
 kubernetes_service_addresses: "172.21.0.0/16"
+kubernetes_nodeport_range: "20000-32767"
 kubernetes_cluster_cidr: "172.34.0.0/16"
 kubernetes_enable_cni: False
 kubernetes_version: "1.14.3"

--- a/templates/kube-apiserver.yaml
+++ b/templates/kube-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
         - --apiserver-count={{groups['kubernetes-masters']|length}}
         - --allow-privileged=true
         - --service-cluster-ip-range={{kubernetes_service_addresses}}
+        - --service-node-port-range={{kubernetes_nodeport_range}}
         - --secure-port={{kube_apiserver_secure_port}}
         - --advertise-address={{ansible_default_ipv4.address}}
         - --feature-gates=PodPriority=true


### PR DESCRIPTION
Increase Cluster NodePort Range from 30000-32767 to 20000-32767.

Tested with a dev cluster and saw kube-apiserver started with the correct option and created a NodePort service, which received a NodePort in a new lower range:
```
root       4484  5.6 10.9 954316 439804 ?       Ssl  21:53   0:22 /hyperkube kube-apiserver --bind-address=0.0.0.0 --etcd-servers=http://10.162.68.133:2379 --apiserver-count=3 --allow-privileged=true --service-cluster-ip-range=172.21.0.0/16 --service-node-port-range=20000-32767 --secure-port=6443

default            alex-simple-flask-app-np   NodePort    172.21.65.25    <none>        5000:28013/TCP           10s
```